### PR TITLE
posenetの導入とkeypointsを画像の上に重ねるところまで

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@mediapipe/pose": "^0.4.1627343400",
-    "@tensorflow-models/pose-detection": "^0.0.4",
+    "@tensorflow-models/posenet": "^2.2.2",
     "@tensorflow/tfjs-backend-wasm": "^3.8.0",
     "@tensorflow/tfjs-backend-webgl": "^3.8.0",
     "@tensorflow/tfjs-converter": "^3.8.0",

--- a/pages/models/rendering.ts
+++ b/pages/models/rendering.ts
@@ -1,105 +1,103 @@
-// ref: https://github.com/tensorflow/tfjs-models/blob/master/pose-detection/demos/live_video/src/camera.js
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import * as posenet from "@tensorflow-models/posenet";
 
-import * as posedetection from "@tensorflow-models/pose-detection";
-import {
-  SupportedModels,
-  Keypoint,
-  Pose,
-} from "@tensorflow-models/pose-detection";
+const color = "aqua";
+const lineWidth = 2;
 
-export const POSENET_CONFIG = {
-  maxPoses: 1,
-  scoreThreshold: 0.5,
-};
+export const tryResNetButtonName = "tryResNetButton";
+export const tryResNetButtonText = "[New] Try ResNet50";
 
-export const DEFAULT_LINE_WIDTH = 2;
-export const DEFAULT_RADIUS = 4;
+function toTuple(keypoint: posenet.Keypoint) {
+  return [keypoint.position.y, keypoint.position.x];
+}
 
-export class Rendering {
-  ctx: CanvasRenderingContext2D;
-  modelName: SupportedModels;
-  modelConfig: any;
+function drawPoint(
+  ctx: CanvasRenderingContext2D,
+  y: number,
+  x: number,
+  r: number,
+  color: string
+) {
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, 2 * Math.PI);
+  ctx.fillStyle = color;
+  ctx.fill();
+}
 
-  constructor(model: SupportedModels, context: CanvasRenderingContext2D) {
-    this.modelName = model;
-    this.ctx = context;
-    this.modelConfig = { ...POSENET_CONFIG };
-  }
+/**
+ * Draws a line on a canvas, i.e. a joint
+ */
+function drawSegment(
+  [ay, ax]: number[],
+  [by, bx]: number[],
+  color: string,
+  scale: number,
+  ctx: CanvasRenderingContext2D
+) {
+  ctx.beginPath();
+  ctx.moveTo(ax * scale, ay * scale);
+  ctx.lineTo(bx * scale, by * scale);
+  ctx.lineWidth = lineWidth;
+  ctx.strokeStyle = color;
+  ctx.stroke();
+}
 
-  /**
-   * Draw the keypoints and skeleton on the video.
-   * @param pose A pose with keypoints to render.
-   */
-  drawResult(pose: Pose) {
-    if (pose.keypoints != null) {
-      this.drawKeypoints(pose.keypoints);
-      this.drawSkeleton(pose.keypoints);
-    }
-  }
-  /**
-   * Draw the keypoints on the video.
-   * @param keypoints A list of keypoints.
-   */
-  drawKeypoints(keypoints: Keypoint[]) {
-    const keypointInd = posedetection.util.getKeypointIndexBySide(
-      this.modelName
+/**
+ * Draws a pose skeleton by looking up all adjacent keypoints/joints
+ */
+export function drawSkeleton(
+  keypoints: posenet.Keypoint[],
+  minConfidence: number,
+  ctx: CanvasRenderingContext2D,
+  scale: number = 1
+) {
+  const adjacentKeyPoints: posenet.Keypoint[][] = posenet.getAdjacentKeyPoints(
+    keypoints,
+    minConfidence
+  );
+  adjacentKeyPoints.forEach((keypoints) => {
+    drawSegment(
+      toTuple(keypoints[0]),
+      toTuple(keypoints[1]),
+      color,
+      scale,
+      ctx
     );
-    this.ctx.fillStyle = "White";
-    this.ctx.strokeStyle = "White";
-    this.ctx.lineWidth = DEFAULT_LINE_WIDTH;
+  });
+}
 
-    for (const i of keypointInd.middle) {
-      this.drawKeypoint(keypoints[i]);
+/**
+ * Draw pose keypoints onto a canvas
+ */
+export function drawKeypoints(
+  keypoints: posenet.Keypoint[],
+  minConfidence: number,
+  ctx: CanvasRenderingContext2D,
+  scale: number = 1
+) {
+  for (let i = 0; i < keypoints.length; i++) {
+    const keypoint = keypoints[i];
+
+    if (keypoint.score < minConfidence) {
+      continue;
     }
 
-    this.ctx.fillStyle = "Green";
-    for (const i of keypointInd.left) {
-      this.drawKeypoint(keypoints[i]);
-    }
-
-    this.ctx.fillStyle = "Orange";
-    for (const i of keypointInd.right) {
-      this.drawKeypoint(keypoints[i]);
-    }
-  }
-
-  drawKeypoint(keypoint: Keypoint) {
-    // If score is null, just show the keypoint.
-    const score = keypoint.score != null ? keypoint.score : 1;
-    const scoreThreshold = this.modelConfig.scoreThreshold || 0;
-
-    if (score >= scoreThreshold) {
-      const circle = new Path2D();
-      circle.arc(keypoint.x, keypoint.y, DEFAULT_RADIUS, 0, 2 * Math.PI);
-      this.ctx.fill(circle);
-      this.ctx.stroke(circle);
-    }
-  }
-
-  /**
-   * Draw the skeleton of a body on the video.
-   * @param keypoints A list of keypoints.
-   */
-  drawSkeleton(keypoints: Keypoint[]) {
-    this.ctx.fillStyle = "White";
-    this.ctx.strokeStyle = "White";
-    this.ctx.lineWidth = DEFAULT_LINE_WIDTH;
-
-    posedetection.util.getAdjacentPairs(this.modelName).forEach(([i, j]) => {
-      const kp1 = keypoints[i];
-      const kp2 = keypoints[j];
-
-      // If score is null, just show the keypoint.
-      const score1 = kp1.score != null ? kp1.score : 1;
-      const score2 = kp2.score != null ? kp2.score : 1;
-      const scoreThreshold = this.modelConfig.scoreThreshold || 0;
-
-      if (score1 >= scoreThreshold && score2 >= scoreThreshold) {
-        this.ctx.beginPath();
-        this.ctx.moveTo(kp1.x, kp1.y);
-        this.ctx.lineTo(kp2.x, kp2.y);
-        this.ctx.stroke();
-      }
-    });
+    const { y, x } = keypoint.position;
+    drawPoint(ctx, y * scale, x * scale, 3, color);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,12 +171,10 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.0.6.tgz#023d72a5c4531b4ce204528971700a78a85a0c50"
   integrity sha512-Myxw//kzromB9yWgS8qYGuGVf91oBUUJpNvy5eM50sqvmKLbKjwLxohJnkWGTeeI9v9IBMtPLxz5Gc60FIfvCA==
 
-"@tensorflow-models/pose-detection@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@tensorflow-models/pose-detection/-/pose-detection-0.0.4.tgz#bf637367d5b5631a055b989b609fbf916ff721c1"
-  integrity sha512-7tNhYqCWuo85l8MesVHl9ZytqlqyG+4pc1jhDIF+2PXPOLcbD1G9EOgqU7d2B1Zo1NHi+j3EdDhI6X1dr25iag==
-  dependencies:
-    rimraf "^3.0.2"
+"@tensorflow-models/posenet@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow-models/posenet/-/posenet-2.2.2.tgz#2abcfa33b43892135d232c9c4408a38cc8f74ba6"
+  integrity sha512-0SXIksRet/IdX7WVH+JSD6W3upkGHix1hwtd3xykIoIMGR7zQ4SC5+wZcNt9ofASyxNYQoI+tUULUo4LNw0c3w==
 
 "@tensorflow/tfjs-backend-cpu@3.8.0":
   version "3.8.0"


### PR DESCRIPTION
## 概要
- ``@tensorflow-models/posenet``を導入する
- https://github.com/tensorflow/tfjs-models/blob/master/posenet/demo/demo_util.js をカメラ映像に重ねる部分

## 画面確認

![6b5b3a29f6eb46b66a82caf703dcf4be](https://user-images.githubusercontent.com/43722788/127730283-8173c8b1-a8ea-4428-8f5a-24af028b70a1.gif)


## 懸念点
- ボタンを押す必要があるからUI的にOKか（カメラ起動時にすぐに導入もできるけど、多分setIntervalでやらないとうまくいかない感があるのでちょっと微妙かも）

## 確認してほしいところ
- 動作問題ないか
- レイアウトは適当なので今はみなくていいです。