### PR TITLE
ローディング文言を追加する

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,12 @@
 {
   "presets": ["next/babel"],
   "plugins": [
-    "styled-components"
+    [
+      "babel-plugin-styled-components",
+      {
+        "ssr": true,
+        "displayName": true
+      }
+    ]
   ]
 }

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -92,7 +92,7 @@ const Loader = () => {
         if (++count == 5) {
           clearInterval(timer)
         }
-      }, 1500)
+      }, 2000)
     }
     return () => {
       isMounted = false

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -87,7 +87,7 @@ const Loader = () => {
     if (isMounted) {
       const timer = setInterval(() => {
         const tempText =
-          LoadingTexts[Math.floor(Math.random() * (LoadingTexts.length + 1))]
+          LoadingTexts[Math.floor(Math.random() * LoadingTexts.length)]
         setText(tempText)
         if (++count == 5) {
           clearInterval(timer)

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled, { keyframes } from 'styled-components'
 
 const DivWrapper = styled.div`
@@ -10,6 +10,7 @@ const DivWrapper = styled.div`
   left: 0;
   right: 0;
   background-color: white;
+  font-family: 'Noto Sans JP', sans-serif;
 `
 
 const LoaderWrapper = styled.div`
@@ -57,7 +58,46 @@ const TopImage = styled.img`
   height: 190px;
 `
 
+const SubText = styled.p`
+  position: absolute;
+  top: 290px;
+  width: 100%;
+  text-align: center;
+  font-weight: 700;
+  font-size: 20px;
+  color: #0a2569;
+`
+
+const LoadingTexts: string[] = [
+  'Loading...',
+  'Wait a moment...',
+  'We are preparing now...',
+  'Give us some seconds',
+  'Sorry for waiting...',
+  'Please keep waiting...',
+  'Just some minutes, please',
+  'You are almost there...',
+]
 const Loader = () => {
+  const [text, setText] = useState<string>(LoadingTexts[1])
+
+  useEffect(() => {
+    let isMounted = true
+    let count = 0
+    if (isMounted) {
+      const timer = setInterval(() => {
+        const tempText =
+          LoadingTexts[Math.floor(Math.random() * (LoadingTexts.length + 1))]
+        setText(tempText)
+        if (++count == 5) {
+          clearInterval(timer)
+        }
+      }, 1500)
+    }
+    return () => {
+      isMounted = false
+    }
+  }, [])
   return (
     <DivWrapper>
       <LoaderWrapper>
@@ -68,6 +108,7 @@ const Loader = () => {
         </Text>
         <LoaderImage src="/svgs/loader.svg" alt="loader" />
         <TopImage src="/svgs/top-icon.svg" alt="loader" />
+        <SubText>{text}</SubText>
       </LoaderWrapper>
     </DivWrapper>
   )

--- a/src/models/RingBuffer.ts
+++ b/src/models/RingBuffer.ts
@@ -19,7 +19,6 @@ export class RingBuffer {
   }
 
   add(keypoints: Keypoint[]) {
-    console.log(this.count, this.size)
     if (this.count >= this.size) {
       for (let i = 0; i < 17; i++) {
         const temp = this.sumArray[i].score || 0

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,7 +20,7 @@ import Modal from '../components/Modal'
 import { Buttons, ReturnButton, SmallText } from '../styles/TopPage'
 import { PhotoPreview } from '../components/PhotoPreview'
 
-type Stage = 'loading' | 'ready' | 'moving' | 'share'
+export type Stage = 'loading' | 'ready' | 'moving' | 'share'
 
 export default function App() {
   const webcamRef = useRef<Webcam>(null)
@@ -141,7 +141,6 @@ export default function App() {
       const mirrorContext = mirrorCanvas.getContext('2d')
 
       if (context && mirrorContext) {
-        console.log(cameraMode)
         if (cameraMode === 'user') {
           mirrorContext.scale(-1, 1)
           mirrorContext.translate(-canvas.width, 0)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,7 +20,7 @@ import Modal from '../components/Modal'
 import { Buttons, ReturnButton, SmallText } from '../styles/TopPage'
 import { PhotoPreview } from '../components/PhotoPreview'
 
-export type Stage = 'loading' | 'ready' | 'moving' | 'share'
+type Stage = 'loading' | 'ready' | 'moving' | 'share'
 
 export default function App() {
   const webcamRef = useRef<Webcam>(null)

--- a/src/styles/TopPage.ts
+++ b/src/styles/TopPage.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 
 export const SmallText = styled.p`
+  font-family: 'Noto Sans JP', sans-serif;
   font-weight: 700;
   font-size: 20px;
   color: #0a2569;


### PR DESCRIPTION
## 概要
- ローディング中だとわかりにくいので文言を追加する

## 実装内容

- ついでに余分なconsoleを削除
- ローディングにフォントがあたってなかったのでフォントをあてました。
- サーバーサイドでstyled-componentsがあたるようにbabelrcを調整
- Loading→Wait a momentだけだと味気がないかなと思って、以下適当な文言を追加しました。


```
const LoadingTexts: string[] = [
  'Loading...',
  'Wait a moment...',
  'We are preparing now...',
  'Give us some seconds',
  'Sorry for waiting...',
  'Please keep waiting...',
  'Just some minutes, please',
  'You are almost there...',
]
```

初期値はLoadingなのはわかるのでWait a moment.を初期値にしてます。
これをランダムで取得。
ピクトグラムみたいに前回のものは表示しないようにしても良いですが、ローディング数秒なのでそこまでする必要もないかとやってないです。

useEffect内でisMountedを返したりしてるのは、setIntervalをuseEffectで使うとunmountのwarningがでるのでそれを防ぐためです。

![image](https://user-images.githubusercontent.com/43722788/127997528-248037a2-4d3e-41fd-b332-e6784558272d.png)

さすがに1.5 * 5秒以内にはローディング終わるだろうということで7.5秒後にタイマーをとめます。

2秒間隔だと少し遅く感じました

## 画面確認

[![Image from Gyazo](https://i.gyazo.com/6c36d661aa8c3470b245202611676554.gif)](https://gyazo.com/6c36d661aa8c3470b245202611676554)