### PR TITLE
終了時のエラーを解消する

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -219,35 +219,31 @@ export default function App() {
       <audio ref={audioRef} preload="true">
         <source src="./pictogram-san_BGM.mp3" type="audio/mp3" />
       </audio>
-      {stage !== 'share' && (
-        <>
-          <Webcam
-            audio={false}
-            mirrored={true}
-            videoConstraints={videoConstraints}
-            ref={webcamRef}
-            style={{
-              position: 'absolute',
-              margin: 'auto',
-              textAlign: 'center',
-              bottom: 0,
-              left: 0,
-              right: 0,
-            }}
-          />
-          <canvas
-            ref={canvasRef}
-            style={{
-              position: 'absolute',
-              margin: 'auto',
-              textAlign: 'center',
-              top: 0,
-              left: 0,
-              right: 0,
-            }}
-          />
-        </>
-      )}
+      <Webcam
+        audio={false}
+        mirrored={true}
+        videoConstraints={videoConstraints}
+        ref={webcamRef}
+        style={{
+          position: 'absolute',
+          margin: 'auto',
+          textAlign: 'center',
+          bottom: 0,
+          left: 0,
+          right: 0,
+        }}
+      />
+      <canvas
+        ref={canvasRef}
+        style={{
+          position: 'absolute',
+          margin: 'auto',
+          textAlign: 'center',
+          top: 0,
+          left: 0,
+          right: 0,
+        }}
+      />
       {!isPC && (
         <ReturnButton
           src="/svgs/return-button.svg"


### PR DESCRIPTION
## 問題点

終了したときに以下のエラーがでる

817-469b8323c2a6480903ac.js:1 Uncaught (in promise) Error: Requested texture size [0x0] is invalid.


## 原因

終了した時点でwebcam要素が取得できないことがエラーの原因なのでstage !== 'share'でしか見れないという条件を外した


## 謎なこと
そもそも、今回、以下で音楽終了→フレーム止める→stageをshareに変えるという順番で動いてるはずなので、なんでこれでエラーになるのかなぞなのですが、非同期で動いてるからとかですかね..?

```
      // 音楽が終了したら止める
      audio.addEventListener('ended', function () {
        cancelAnimationFrame(animationFrameId)
        if (audio) audio.pause()
        setStage('share')
      })
```